### PR TITLE
Contact Info & Map Widget: improvements to Geocoding changes

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -257,10 +257,17 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			</p>
 
 			<?php
-			if ( ! is_customize_preview() ) {
+			if (
+				! is_customize_preview()
+				&& $instance['showmap']
+				&& ! empty( $instance['address'] )
+				&& ! empty( $apikey )
+			) {
 				?>
-				<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
-					<?php echo $this->build_map( $instance['address'], $apikey ); ?>
+				<p class="jp-contact-info-admin-map">
+					<?php
+						echo $this->build_map( $instance['address'], $apikey ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
 				</p>
 				<?php
 			}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -20,6 +20,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		 * Constructor
 		 */
 		function __construct() {
+			global $pagenow;
+
 			$widget_ops = array(
 				'classname'                   => 'widget_contact_info',
 				'description'                 => __( 'Display a map with your location, hours, and contact information.', 'jetpack' ),
@@ -33,7 +35,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			);
 			$this->alt_option_name = 'widget_contact_info';
 
-			if ( is_customize_preview() ) {
+			if ( is_customize_preview() || 'widgets.php' === $pagenow ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			}
 		}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -359,9 +359,9 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			/** This filter is documented in modules/widgets/contact-info.php */
 			$api_key = apply_filters( 'jetpack_google_maps_api_key', $instance['apikey'] );
 			if ( ! empty( $api_key ) ) {
-				$path = add_query_arg( 'q', rawurlencode( $instance['address'] ), 'https://www.google.com/maps/embed/v1/place' );
-				$path = add_query_arg( 'key', $api_key, $path );
-				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url( $path, null, null ) ) );
+				$path          = add_query_arg( 'q', rawurlencode( $instance['address'] ), 'https://www.google.com/maps/embed/v1/place' );
+				$path          = add_query_arg( 'key', $api_key, $path );
+				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url_raw( $path ) ) );
 
 				return 200 === $response_code;
 			}

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -178,19 +178,28 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				$instance['showmap'] = intval( $new_instance['showmap'] );
 			}
 
+			/*
+			 * If there have been any changes that may impact the map in the widget
+			 * (adding an address, address changes, new API key, API key change )
+			 * then we want to check whether our map can be displayed again.
+			 */
 			$update_goodmap = false;
 			if (
-				! isset( $instance['goodmap'] ) ||
-				! isset( $old_instance['address'] ) ||
-				$this->urlencode_address( $old_instance['address'] ) != $this->urlencode_address( $new_instance['address'] ) ||
-				! isset( $old_instance['apikey'] ) ||
-				$old_instance['apikey'] != $new_instance['apikey']
+				! isset( $instance['goodmap'] )
+				|| ! isset( $old_instance['address'] )
+				|| $this->urlencode_address( $old_instance['address'] ) !== $this->urlencode_address( $new_instance['address'] )
+				|| ! isset( $old_instance['apikey'] )
+				|| $old_instance['apikey'] !== $new_instance['apikey']
 			) {
 				$update_goodmap = true;
 			}
 
-			if ( empty( $instance['address'] ) || $instance['showmap'] === 0) {
-					$update_goodmap = false;
+			/*
+			 * If we have no address or don't want to show a map,
+			 * no need to check if the map is valid
+			 */
+			if ( empty( $instance['address'] ) || 0 === $instance['showmap'] ) {
+					$update_goodmap      = false;
 					$instance['goodmap'] = false;
 			}
 

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -368,8 +368,13 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			/** This filter is documented in modules/widgets/contact-info.php */
 			$api_key = apply_filters( 'jetpack_google_maps_api_key', $instance['apikey'] );
 			if ( ! empty( $api_key ) ) {
-				$path          = add_query_arg( 'q', rawurlencode( $instance['address'] ), 'https://www.google.com/maps/embed/v1/place' );
-				$path          = add_query_arg( 'key', $api_key, $path );
+				$path          = add_query_arg(
+					array(
+						'q'   => rawurlencode( $instance['address'] ),
+						'key' => $api_key,
+					),
+					'https://www.google.com/maps/embed/v1/place'
+				);
 				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url_raw( $path ) ) );
 
 				return 200 === $response_code;

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				$showmap = $instance['showmap'];
 				$goodmap = isset( $instance['goodmap'] ) ? $instance['goodmap'] : $this->has_good_map( $instance );
 
-				if ( $showmap && $goodmap ) {
+				if ( $showmap && true === $goodmap ) {
 					/**
 					 * Set a Google Maps API Key.
 					 *
@@ -258,22 +258,25 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				</label>
 			</p>
 
-			<?php
-			if (
-				! is_customize_preview()
-				&& $instance['showmap']
-				&& ! empty( $instance['address'] )
-				&& ! empty( $apikey )
-			) {
-				?>
-				<p class="jp-contact-info-admin-map">
-					<?php
-						echo $this->build_map( $instance['address'], $apikey ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					?>
-				</p>
+			<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<?php
-			}
-			?>
+				if (
+					! is_customize_preview()
+					&& $instance['showmap']
+					&& ! empty( $instance['address'] )
+					&& ! empty( $apikey )
+				) {
+					if ( true === $this->has_good_map( $instance ) ) {
+						echo $this->build_map( $instance['address'], $apikey ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					} else {
+						printf(
+							'<span class="notice notice-warning" style="display: block;">%s</span>',
+							esc_html( $this->has_good_map( $instance ) )
+						);
+					}
+				}
+				?>
+			</p>
 
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'phone' ) ); ?>"><?php esc_html_e( 'Phone:', 'jetpack' ); ?></label>
@@ -371,25 +374,29 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 		 *
 		 * @param array $instance Widget instance configuration.
 		 *
-		 * @return bool Whether or not there is a valid map.
+		 * @return bool|string Whether or not there is a valid map. If not, return an error message.
 		 */
 		function has_good_map( $instance ) {
 			/** This filter is documented in modules/widgets/contact-info.php */
 			$api_key = apply_filters( 'jetpack_google_maps_api_key', $instance['apikey'] );
 			if ( ! empty( $api_key ) ) {
-				$path          = add_query_arg(
+				$path     = add_query_arg(
 					array(
 						'q'   => rawurlencode( $instance['address'] ),
 						'key' => $api_key,
 					),
 					'https://www.google.com/maps/embed/v1/place'
 				);
-				$response_code = wp_remote_retrieve_response_code( wp_remote_get( esc_url_raw( $path ) ) );
+				$response = wp_remote_get( esc_url_raw( $path ) );
 
-				return 200 === $response_code;
+				if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+					return true;
+				} else {
+					return wp_remote_retrieve_body( $response );
+				}
 			}
 
-			return false;
+			return __( 'Please enter a valid Google API Key.', 'jetpack' );
 		}
 
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR extends on https://github.com/Automattic/jetpack/pull/12474 with some changes:

- Rely on `esc_url_raw` for remote call
- Clarify update process for the map, and coding standard changes
    - A few additional comments help understand when `has_good_map` is needed.
    - Use Yoda conditions, we must
- Simplify addition of query params to Google embed URL.
- Enqueue CSS on widgets page as well: this avoids that the map breaks out of the widget area layout when displayed.
- Display output from API request in widget area when error. This gives more information to users who entered an API key that is not correct for example, instead of just not displaying any map at all.

#### Testing instructions:

* They should be the same as https://github.com/Automattic/jetpack/pull/12474
* In addition to this, I'd recommend trying to input a wrong API key to see the error messages being displayed in the widget areas.
* Those error messages are only displayed in the old Widgets Screen, which is still a problem imo. In my opinion we should display those in the Customizer as well.

#### Proposed changelog entry for your changes:

* None
